### PR TITLE
Fix "ypeError: Cannot call method 'walk' of undefined"

### DIFF
--- a/bin/uglifyjs
+++ b/bin/uglifyjs
@@ -470,7 +470,7 @@ function normalize(o) {
 
 function getOptions(x, constants) {
     x = ARGS[x];
-    if (x == null) return null;
+    if (!x) return null;
     var ret = {};
     if (x !== "") {
         var ast;


### PR DESCRIPTION
problem with the uglify assetic filter who add option "no-mangle".
Since : https://github.com/mishoo/UglifyJS2/commit/3ef092332b1e7c9bf1d17038601a33bd742dd753#diff-e5511a595da8371c33a33346f3e22fd4L460

Assetic dump error :
```
** [err :: pp-app54-recette-01] 
*** [err :: pp-app54-recette-01] Error Output:
*** [err :: pp-app54-recette-01] 
*** [err :: pp-app54-recette-01] /srv/deploy/recette/***@jenkins-1756/releases/20150331070037/node_modules/uglify-js/
bin/uglifyjs:485
  *** [err :: pp-app54-recette-01] ast.walk(new UglifyJS.TreeWalker(function(node){
  *** [err :: pp-app54-recette-01] ^
  *** [err :: pp-app54-recette-01] TypeError: Cannot call method 'walk' of undefined
  *** [err :: pp-app54-recette-01] at getOptions (/srv/deploy/recette/***@jenkins-1756/releases/20150331070037/node_modules/uglify-js/bin/uglifyjs:485:13)
  *** [err :: pp-app54-recette-01] at Object.<anonymous> (/srv/deploy/recette/***@jenkins-1756/releases/20150331070037/node_modules/uglify-js/bin/uglifyjs:161:14)
  *** [err :: pp-app54-recette-01] at Module._compile (module.js:456:26)
  *** [err :: pp-app54-recette-01] at Object.Module._extensions..js (module.js:474:10)
  *** [err :: pp-app54-recette-01] at Module.load (module.js:356:32)
  *** [err :: pp-app54-recette-01] at Function.Module._load (module.js:312:12)
  *** [err :: pp-app54-recette-01] at Function.Module.runMain (module.js:497:10)
  *** [err :: pp-app54-recette-01] at startup (node.js:119:16)
  *** [err :: pp-app54-recette-01] at node.js:935:3
```